### PR TITLE
Added WPML compatibility

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -106,7 +106,7 @@ class Ajax {
         }
         $results = [];
 
-        foreach ($order->get_items() as $id => $item) {
+        foreach (Helper::getOrderItems($order) as $id => $item) {
             array_push($results, [
                 'id' => $id,
                 'name' => $item->get_name(),
@@ -159,7 +159,7 @@ class Ajax {
         }
         $orderId = absint($_POST['orderId']);
         $order = wc_get_order($orderId);
-        $orderItems = $order->get_items();
+        $orderItems = Helper::getOrderItems($order);
         $shipmentId = sanitize_key($_POST['id']);
         $shipment = Helper::geShipmentWithJoinedItems($shipmentId, $orderId);
 
@@ -227,7 +227,7 @@ class Ajax {
 
         // Order data.
         $order               = wc_get_order($orderId);
-        $orderItems          = $order->get_items();
+        $orderItems          = Helper::getOrderItems($order);
         $orderNotes          = [];
 
         try {
@@ -333,7 +333,7 @@ class Ajax {
 
         // Order data.
         $order               = wc_get_order($orderId);
-        $orderItems          = $order->get_items();
+        $orderItems          = Helper::getOrderItems($order);
         try {
             $mergedItems = [];
             foreach ($shipment['items'] as $item) {
@@ -408,7 +408,7 @@ class Ajax {
 
         // Order data.
         $order               = wc_get_order($orderId);
-        $orderItems          = $order->get_items();
+        $orderItems          = Helper::getOrderItems($order);
 
         /** @var \WP_User $user */
         $user = wp_get_current_user();

--- a/src/Synchronization/ShipmentSync.php
+++ b/src/Synchronization/ShipmentSync.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Exception\ClientException;
 use TrackMage\Client\TrackMageClient;
 use TrackMage\WordPress\Exception\InvalidArgumentException;
 use TrackMage\WordPress\Exception\SynchronizationException;
+use TrackMage\WordPress\Helper;
 use TrackMage\WordPress\Plugin;
 
 class ShipmentSync implements EntitySyncInterface
@@ -55,7 +56,7 @@ class ShipmentSync implements EntitySyncInterface
                         'orders' => ['/orders/'.$trackmage_order_id],
                     ];
                     if(isset($shipment['items'])){
-                        $data['shipmentItems'] = $this->getShipmentItemsForSync($shipment['items'], $order->get_items());
+                        $data['shipmentItems'] = $this->getShipmentItemsForSync($shipment['items'], Helper::getOrderItems($order));
                     }
                     $response = $client->post('/shipments', [
                         'headers' => [
@@ -78,7 +79,7 @@ class ShipmentSync implements EntitySyncInterface
                         $data['originCarrier'] = $shipment['carrier'] === 'auto' ? null : $shipment['carrier'];
                     }
                     if ( isset( $shipment['items'] ) ) {
-                        $data['shipmentItems'] = $this->getShipmentItemsForSync( $shipment['items'], $order->get_items() );
+                        $data['shipmentItems'] = $this->getShipmentItemsForSync( $shipment['items'], Helper::getOrderItems($order) );
                     }
                     $response = $client->put( '/shipments/' . $trackmage_id, [
                         'headers' => [

--- a/src/TrackingInfo.php
+++ b/src/TrackingInfo.php
@@ -17,7 +17,7 @@ class TrackingInfo {
         if (null === $link = Helper::getOrderTrackingPageLink($order)) {
             return;
         }
-        printf( '<p>Track your order <strong><a href="%s">here</a></strong>.</p>', esc_url( $link, array( 'http', 'https' )));
+        printf( '<p>%s <strong><a href="%s">%s</a></strong>.</p>', __('Track your order', 'trackmage'), esc_url( $link, array( 'http', 'https' )), __('here', 'trackmage'));
     }
 
     /**
@@ -33,6 +33,6 @@ class TrackingInfo {
         if (null === $link = Helper::getOrderTrackingPageLink($order)) {
             return;
         }
-        printf( '<p>Track your order <strong><a href="%s">here</a></strong>.</p>', esc_url( $link, array( 'http', 'https' )));
+        printf( '<p>%s <strong><a href="%s">%s</a></strong>.</p>', __('Track your order', 'trackmage'), esc_url( $link, array( 'http', 'https' )), __('here', 'trackmage'));
     }
 }


### PR DESCRIPTION
We can also replace `wc_get_order` with `WC_Data_Store::load( 'order' )->get_order_type( $order_id );`
But looks like it works fine with `wc_get_order`, so probably there is no point.